### PR TITLE
Avoid realloc when inserting into OwnedHeaders or sending record

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -534,7 +534,7 @@ impl OwnedHeaders {
     where
         V: ToBytes + ?Sized,
     {
-        let name_cstring = CString::new(header.key.to_owned()).unwrap();
+        let name_cstring = CString::new(header.key).unwrap();
         let (value_ptr, value_len) = match header.value {
             None => (ptr::null_mut(), 0),
             Some(value) => {

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -442,7 +442,7 @@ where
         }
         let (payload_ptr, payload_len) = as_bytes(record.payload);
         let (key_ptr, key_len) = as_bytes(record.key);
-        let topic_cstring = CString::new(record.topic.to_owned()).unwrap();
+        let topic_cstring = CString::new(record.topic).unwrap();
         let opaque_ptr = record.delivery_opaque.into_ptr();
         let produce_error = unsafe {
             rdsys::rd_kafka_producev(


### PR DESCRIPTION
Avoid alloc + realloc right after by allocating enough to hold input string + \0.

![Screenshot 2024-08-20 at 15 58 32](https://github.com/user-attachments/assets/71e1a4e3-239f-4f2c-a7a4-0e51d0adaf84)

Profile is only from time where only src/messager.rs was patched and not base producer.
