### PR TITLE
[EPW-3467] Expose leader epoch for toppar element

### DIFF
--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -154,6 +154,11 @@ impl<'a> TopicPartitionListElem<'a> {
         self.ptr.metadata = buf;
         self.ptr.metadata_size = metadata.len();
     }
+
+    /// Returns leader epoch associated with the entry.
+    pub fn leader_epoch(&self) -> i32 {
+        unsafe { rdsys::rd_kafka_topic_partition_get_leader_epoch(self.ptr) }
+    }
 }
 
 impl<'a> PartialEq for TopicPartitionListElem<'a> {


### PR DESCRIPTION
As a follow-up will push the change upstream.

Libstreaming still relies on librdkafka to fetch committed offsets + metadata so extending the API to give us also leader epoch in order to properly implement KIP-320.