### PR TITLE
Fix handle_log_event UB

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ use crate::config::{ClientConfig, NativeClientConfig, RDKafkaLogLevel};
 use crate::consumer::RebalanceProtocol;
 use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::groups::GroupList;
-use crate::log::{debug, error, info, trace, warn, LogRecord};
+use crate::log::{LogRecord, debug, error, info, trace, warn};
 use crate::metadata::Metadata;
 use crate::mocking::MockCluster;
 use crate::statistics::Statistics;
@@ -353,15 +353,11 @@ impl<C: ClientContext> Client<C> {
                 )
             };
             let contexts = if result == 0 {
-                let mut csv = unsafe { CString::from_vec_with_nul_unchecked(raw_contents) }
-                    .to_string_lossy()
-                    .into_owned();
-                if let Some(idx) = csv.find("\0") {
-                    csv.truncate(idx);
-                }
-                csv
+                let cstr = CStr::from_bytes_until_nul(&raw_contents)
+                    .expect("raw_contents always contains a NULL byte");
+                cstr.to_string_lossy().into_owned()
             } else {
-                "".to_string()
+                String::new()
             };
             self.context().log(LogRecord::new(
                 level.into(),
@@ -434,7 +430,10 @@ impl<C: ClientContext> Client<C> {
                 let message = match CString::new(e.to_string()) {
                     Ok(message) => message,
                     Err(e) => {
-                        error!("error message generated while refreshing OAuth token has embedded null character: {}", e);
+                        error!(
+                            "error message generated while refreshing OAuth token has embedded null character: {}",
+                            e
+                        );
                         CString::new(
                             "error while refreshing OAuth token has embedded null character",
                         )


### PR DESCRIPTION
rdkafka may not fill the entire buffer, resulting in multiple NULL bytes causing segfault:
```
[        19.435] [event-context-skeleton-ddgo] [err] thread 'tokio-runtime-worker' (35) panicked at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/ffi/c_str.rs:631:9:
[        19.435] [event-context-skeleton-ddgo] [err] assertion failed: memchr::memchr(0, &v).unwrap() + 1 == v.len()
[        19.435] [event-context-skeleton-ddgo] [err] note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[        19.436] [event-context-skeleton-ddgo] [err] 
[        19.436] [event-context-skeleton-ddgo] [err] thread 'tokio-runtime-worker' (35) panicked at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/ffi/c_str.rs:631:9:
[        19.436] [event-context-skeleton-ddgo] [err] assertion failed: memchr::memchr(0, &v).unwrap() + 1 == v.len()
[        19.436] [event-context-skeleton-ddgo] [err] stack backtrace:
[        21.612] [event-context-skeleton-ddgo] [err]    0:     0x7f209922c4d5 - std[76459fe1f20d1bd4]::backtrace_rs::backtrace::libunwind::trace
[        21.612] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
[        21.612] [event-context-skeleton-ddgo] [err]    1:     0x7f209922c4d5 - std[76459fe1f20d1bd4]::backtrace_rs::backtrace::trace_unsynchronized::<std[76459fe1f20d1bd4]::sys::backtrace::_print_fmt::{closure#1}>
[        21.612] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
[        21.612] [event-context-skeleton-ddgo] [err]    2:     0x7f209939b4e4 - std[76459fe1f20d1bd4]::sys::backtrace::_print_fmt
[        21.612] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:68:9
[        21.612] [event-context-skeleton-ddgo] [err]    3:     0x7f20993c1c89 - <<std[76459fe1f20d1bd4]::sys::backtrace::BacktraceLock>::print::DisplayBacktrace as core[ecc4e217c0cb0dbe]::fmt::Display>::fmt
[        21.612] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:38:26
[        21.710] [event-context-skeleton-ddgo] [err]    4:     0x7f20994ec1c1 - <core[ecc4e217c0cb0dbe]::fmt::rt::Argument>::fmt
[        21.710] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/rt.rs:152:76
[        21.710] [event-context-skeleton-ddgo] [err]    5:     0x7f209950792c - core[ecc4e217c0cb0dbe]::fmt::write
[        21.710] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/mod.rs:1686:22
[        21.710] [event-context-skeleton-ddgo] [err]    6:     0x7f209921794c - std[76459fe1f20d1bd4]::io::default_write_fmt::<std[76459fe1f20d1bd4]::sys::stdio::unix::Stderr>
[        21.710] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/io/mod.rs:614:11
[        21.711] [event-context-skeleton-ddgo] [err]    7:     0x7f20994277a9 - <std[76459fe1f20d1bd4]::sys::stdio::unix::Stderr as std[76459fe1f20d1bd4]::io::Write>::write_fmt
[        21.711] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/io/mod.rs:1969:13
[        21.711] [event-context-skeleton-ddgo] [err]    8:     0x7f20992c901f - <std[76459fe1f20d1bd4]::sys::backtrace::BacktraceLock>::print
[        21.711] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:41:9
[        21.711] [event-context-skeleton-ddgo] [err]    9:     0x7f20992ae1e2 - std[76459fe1f20d1bd4]::panicking::default_hook::{closure#0}
[        21.711] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:292:27
[        21.711] [event-context-skeleton-ddgo] [err]   10:     0x7f2099397bb4 - std[76459fe1f20d1bd4]::panicking::default_hook
[        21.711] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:319:9
[        21.711] [event-context-skeleton-ddgo] [err]   11:     0x7f2099398779 - std[76459fe1f20d1bd4]::panicking::panic_with_hook
[        21.711] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:825:13
[        21.711] [event-context-skeleton-ddgo] [err]   12:     0x7f20992ae5a8 - std[76459fe1f20d1bd4]::panicking::panic_handler::{closure#0}
[        21.711] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:691:13
[        21.711] [event-context-skeleton-ddgo] [err]   13:     0x7f209922e06f - std[76459fe1f20d1bd4]::sys::backtrace::__rust_end_short_backtrace::<std[76459fe1f20d1bd4]::panicking::panic_handler::{closure#0}, !>
[        21.711] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:176:18
[        21.711] [event-context-skeleton-ddgo] [err]   14:     0x7f20992b72ab - __rustc[b1c156c3cad71f26]::rust_begin_unwind
[        21.711] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:689:5
[        21.711] [event-context-skeleton-ddgo] [err]   15:     0x7f2099509fd0 - core[ecc4e217c0cb0dbe]::panicking::panic_fmt
[        21.711] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:80:14
[        21.711] [event-context-skeleton-ddgo] [err]   16:     0x7f2099509eba - core[ecc4e217c0cb0dbe]::panicking::panic
[        21.711] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:150:5
[        21.734] [event-context-skeleton-ddgo] [err]   17:     0x7f20994ac488 - <alloc[6fedee528f97f968]::ffi::c_str::CString>::from_vec_with_nul_unchecked
[        21.734] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/ffi/c_str.rs:631:9
[        22.087] [event-context-skeleton-ddgo] [err]   18:     0x7f2096d0665a - <rdkafka[ed2f1d2f3f026198]::client::Client<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumerContext<rdkafka[ed2f1d2f3f026198]::consumer::DefaultConsumerContext>>>::handle_log_event
[        22.087] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/git/checkouts/rust-rdkafka-1dbb685b09f0a236/ca0bb6b/src/client.rs:356:40
[        22.087] [event-context-skeleton-ddgo] [err]   19:     0x7f2096c3528e - <rdkafka[ed2f1d2f3f026198]::client::Client<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumerContext<rdkafka[ed2f1d2f3f026198]::consumer::DefaultConsumerContext>>>::poll_event::<rdkafka[ed2f1d2f3f026198]::util::Timeout>
[        22.087] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/git/checkouts/rust-rdkafka-1dbb685b09f0a236/ca0bb6b/src/client.rs:310:26
[        22.087] [event-context-skeleton-ddgo] [err]   20:     0x7f2096c2e794 - <rdkafka[ed2f1d2f3f026198]::consumer::base_consumer::BaseConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumerContext<rdkafka[ed2f1d2f3f026198]::consumer::DefaultConsumerContext>>>::poll_queue::<core[ecc4e217c0cb0dbe]::time::Duration>
[        22.088] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/git/checkouts/rust-rdkafka-1dbb685b09f0a236/ca0bb6b/src/consumer/base_consumer.rs:133:45
[        22.088] [event-context-skeleton-ddgo] [err]   21:     0x7f2096c2f2fa - <rdkafka[ed2f1d2f3f026198]::consumer::base_consumer::BaseConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumerContext<rdkafka[ed2f1d2f3f026198]::consumer::DefaultConsumerContext>>>::poll::<core[ecc4e217c0cb0dbe]::time::Duration>
[        22.088] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/git/checkouts/rust-rdkafka-1dbb685b09f0a236/ca0bb6b/src/consumer/base_consumer.rs:119:14
[        22.088] [event-context-skeleton-ddgo] [err]   22:     0x7f2096d3eedf - <rdkafka[ed2f1d2f3f026198]::consumer::base_consumer::BaseConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumerContext<rdkafka[ed2f1d2f3f026198]::consumer::DefaultConsumerContext>> as core[ecc4e217c0cb0dbe]::ops::drop::Drop>::drop
[        22.088] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/git/checkouts/rust-rdkafka-1dbb685b09f0a236/ca0bb6b/src/consumer/base_consumer.rs:771:26
[        22.088] [event-context-skeleton-ddgo] [err]   23:     0x7f2096c6a267 - core[ecc4e217c0cb0dbe]::ptr::drop_in_place::<rdkafka[ed2f1d2f3f026198]::consumer::base_consumer::BaseConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumerContext<rdkafka[ed2f1d2f3f026198]::consumer::DefaultConsumerContext>>>
[        22.088] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:805:1
[        22.088] [event-context-skeleton-ddgo] [err]   24:     0x7f2096d0e28c - <kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>::new_with_context
[        22.088] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/kafka/libs/rust/client/src/kafka/consumer/measuring_consumer.rs:549:5
[        22.088] [event-context-skeleton-ddgo] [err]   25:     0x7f2096d020fb - <kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>::new
[        22.088] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/kafka/libs/rust/client/src/kafka/consumer/measuring_consumer.rs:419:9
[        22.111] [event-context-skeleton-ddgo] [err]   26:     0x7f2096c24a65 - <kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer as libnotification[70ffda884b5414]::consumer::KafkaPoll>::new
[        22.111] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libnotification/src/consumer.rs:122:24
[        22.728] [event-context-skeleton-ddgo] [err]   27:     0x7f2095949f96 - <libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>>::build_consumer::{closure#0}::{closure#0}
[        22.728] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libnotification/src/consumer.rs:527:24
[        22.728] [event-context-skeleton-ddgo] [err]   28:     0x7f20959eb82a - <libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>>::build_consumer::{closure#0}
[        22.728] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libnotification/src/consumer.rs:454:5
[        22.728] [event-context-skeleton-ddgo] [err]   29:     0x7f209594cda9 - <libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>>::new::{closure#0}::{closure#0}
[        22.728] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libnotification/src/consumer.rs:419:88
[        22.728] [event-context-skeleton-ddgo] [err]   30:     0x7f20959ef75e - <libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>>::new::{closure#0}
[        22.728] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libnotification/src/consumer.rs:369:5
[        22.729] [event-context-skeleton-ddgo] [err]   31:     0x7f209596be02 - <libnotification[70ffda884b5414]::consumer::SingleClusterNotificationManager as libnotification[70ffda884b5414]::consumer::NotificationManager<libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>>>::build_consumer::{closure#0}::{closure#0}
[        22.729] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libnotification/src/consumer.rs:272:10
[        22.729] [event-context-skeleton-ddgo] [err]   32:     0x7f2095a4d2c7 - <libnotification[70ffda884b5414]::consumer::SingleClusterNotificationManager as libnotification[70ffda884b5414]::consumer::NotificationManager<libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>>>::build_consumer::{closure#0}
[        22.729] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libnotification/src/consumer.rs:257:5
[        22.729] [event-context-skeleton-ddgo] [err]   33:     0x7f2095c4b303 - <core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<dyn core[ecc4e217c0cb0dbe]::future::future::Future<Output = core[ecc4e217c0cb0dbe]::result::Result<alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::sync::rwlock::RwLock<libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>>>, anyhow[c35b6e30a65dde7e]::Error>> + core[ecc4e217c0cb0dbe]::marker::Send>> as core[ecc4e217c0cb0dbe]::future::future::Future>::poll
[        22.729] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
[        22.729] [event-context-skeleton-ddgo] [err]   34:     0x7f209592f921 - <libcontext[ebeebc2c2451c796]::context::EvpContext<libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>, libnotification[70ffda884b5414]::consumer::SingleClusterNotificationManager>>::setup_notification_consumer::{closure#0}::{closure#0}
[        22.729] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libcontext/src/context.rs:348:14
[        22.730] [event-context-skeleton-ddgo] [err]   35:     0x7f20959a31d1 - <libcontext[ebeebc2c2451c796]::context::EvpContext<libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>, libnotification[70ffda884b5414]::consumer::SingleClusterNotificationManager>>::setup_notification_consumer::{closure#0}
[        22.730] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libcontext/src/context.rs:327:5
[        22.730] [event-context-skeleton-ddgo] [err]   36:     0x7f2095c44a8c - <tokio[a99d4c33085cc326]::time::timeout::Timeout<<libcontext[ebeebc2c2451c796]::context::EvpContext<libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>, libnotification[70ffda884b5414]::consumer::SingleClusterNotificationManager>>::setup_notification_consumer::{closure#0}> as core[ecc4e217c0cb0dbe]::future::future::Future>::poll
[        22.730] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/time/timeout.rs:202:42
[        22.730] [event-context-skeleton-ddgo] [err]   37:     0x7f209592c2e6 - <libcontext[ebeebc2c2451c796]::context::EvpContext<libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>, libnotification[70ffda884b5414]::consumer::SingleClusterNotificationManager>>::init_notifications::{closure#0}::{closure#0}
[        22.730] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libcontext/src/context.rs:295:14
[        22.730] [event-context-skeleton-ddgo] [err]   38:     0x7f209599d932 - <libcontext[ebeebc2c2451c796]::context::EvpContext<libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>, libnotification[70ffda884b5414]::consumer::SingleClusterNotificationManager>>::init_notifications::{closure#0}
[        22.730] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libcontext/src/context.rs:288:5
[        22.730] [event-context-skeleton-ddgo] [err]   39:     0x7f2095933cec - <libcontext[ebeebc2c2451c796]::context::EvpContext<libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>, libnotification[70ffda884b5414]::consumer::SingleClusterNotificationManager>>::init_context_from_staged_rocksdb::{closure#0}::{closure#0}
[        22.730] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libcontext/src/context.rs:264:70
[        22.730] [event-context-skeleton-ddgo] [err]   40:     0x7f20959a809f - <libcontext[ebeebc2c2451c796]::context::EvpContext<libnotification[70ffda884b5414]::consumer::SingleClusterNotificationConsumer<kafka_client[9887efc03875596a]::kafka::consumer::measuring_consumer::MeasuringConsumer>, libnotification[70ffda884b5414]::consumer::SingleClusterNotificationManager>>::init_context_from_staged_rocksdb::{closure#0}
[        22.730] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libcontext/src/context.rs:215:5
[        22.730] [event-context-skeleton-ddgo] [err]   41:     0x7f209591f2e9 - <libcontext[ebeebc2c2451c796]::context_manager::ContextRefresh>::refresh_context::{closure#0}::{closure#0}
[        22.731] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libcontext/src/context_manager.rs:297:18
[        22.731] [event-context-skeleton-ddgo] [err]   42:     0x7f2095995a7b - <libcontext[ebeebc2c2451c796]::context_manager::ContextRefresh>::refresh_context::{closure#0}
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libcontext/src/context_manager.rs:242:5
[        22.732] [event-context-skeleton-ddgo] [err]   43:     0x7f2095c44171 - <tokio[a99d4c33085cc326]::time::timeout::Timeout<<libcontext[ebeebc2c2451c796]::context_manager::ContextRefresh>::refresh_context::{closure#0}> as core[ecc4e217c0cb0dbe]::future::future::Future>::poll
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/time/timeout.rs:202:42
[        22.732] [event-context-skeleton-ddgo] [err]   44:     0x7f209590f2b3 - <libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}::{closure#0}
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libcontext/src/context_manager.rs:533:30
[        22.732] [event-context-skeleton-ddgo] [err]   45:     0x7f2095be539e - <tracing[b2e653f2b9a26bb4]::instrument::Instrumented<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}::{closure#0}> as core[ecc4e217c0cb0dbe]::future::future::Future>::poll
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-0.1.41/src/instrument.rs:321:15
[        22.732] [event-context-skeleton-ddgo] [err]   46:     0x7f2095935776 - <libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/go/src/github.com/DataDog/dd-source/domains/event-platform/shared/libs/rust/libcontext/src/context_manager.rs:611:18
[        22.732] [event-context-skeleton-ddgo] [err]   47:     0x7f2095c4c1e9 - <core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>> as core[ecc4e217c0cb0dbe]::future::future::Future>::poll
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
[        22.732] [event-context-skeleton-ddgo] [err]   48:     0x7f20959f63d2 - <tokio[a99d4c33085cc326]::runtime::task::core::Core<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>>::poll::{closure#0}
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/core.rs:365:24
[        22.732] [event-context-skeleton-ddgo] [err]   49:     0x7f2095b7084f - <tokio[a99d4c33085cc326]::loom::std::unsafe_cell::UnsafeCell<tokio[a99d4c33085cc326]::runtime::task::core::Stage<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>>>>::with_mut::<core[ecc4e217c0cb0dbe]::task::poll::Poll<()>, <tokio[a99d4c33085cc326]::runtime::task::core::Core<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>>::poll::{closure#0}>
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/loom/std/unsafe_cell.rs:16:9
[        22.732] [event-context-skeleton-ddgo] [err]   50:     0x7f2095b7084f - <tokio[a99d4c33085cc326]::runtime::task::core::Core<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>>::poll
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/core.rs:354:30
[        22.732] [event-context-skeleton-ddgo] [err]   51:     0x7f20958d1b3c - tokio[a99d4c33085cc326]::runtime::task::harness::poll_future::<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>::{closure#0}
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:535:30
[        22.732] [event-context-skeleton-ddgo] [err]   52:     0x7f2095c84cf0 - <core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<tokio[a99d4c33085cc326]::runtime::task::harness::poll_future<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>::{closure#0}> as core[ecc4e217c0cb0dbe]::ops::function::FnOnce<()>>::call_once
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
[        22.732] [event-context-skeleton-ddgo] [err]   53:     0x7f2095816137 - std[76459fe1f20d1bd4]::panicking::catch_unwind::do_call::<core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<tokio[a99d4c33085cc326]::runtime::task::harness::poll_future<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>::{closure#0}>, core[ecc4e217c0cb0dbe]::task::poll::Poll<()>>
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
[        22.732] [event-context-skeleton-ddgo] [err]   54:     0x7f2095cb9f3b - __rust_try
[        22.732] [event-context-skeleton-ddgo] [err]   55:     0x7f2095751c3f - std[76459fe1f20d1bd4]::panicking::catch_unwind::<core[ecc4e217c0cb0dbe]::task::poll::Poll<()>, core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<tokio[a99d4c33085cc326]::runtime::task::harness::poll_future<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>::{closure#0}>>
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
[        22.732] [event-context-skeleton-ddgo] [err]   56:     0x7f209574113c - std[76459fe1f20d1bd4]::panic::catch_unwind::<core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<tokio[a99d4c33085cc326]::runtime::task::harness::poll_future<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>::{closure#0}>, core[ecc4e217c0cb0dbe]::task::poll::Poll<()>>
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
[        22.732] [event-context-skeleton-ddgo] [err]   57:     0x7f20957fea2e - tokio[a99d4c33085cc326]::runtime::task::harness::poll_future::<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:523:18
[        22.732] [event-context-skeleton-ddgo] [err]   58:     0x7f2095abc8d4 - <tokio[a99d4c33085cc326]::runtime::task::harness::Harness<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>>::poll_inner
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:210:27
[        22.732] [event-context-skeleton-ddgo] [err]   59:     0x7f2095abd0dd - <tokio[a99d4c33085cc326]::runtime::task::harness::Harness<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>>::poll
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:155:20
[        22.732] [event-context-skeleton-ddgo] [err]   60:     0x7f20957f52dd - tokio[a99d4c33085cc326]::runtime::task::raw::poll::<core[ecc4e217c0cb0dbe]::pin::Pin<alloc[6fedee528f97f968]::boxed::Box<<libcontext[ebeebc2c2451c796]::context_manager::EvpContextManager>::new::{closure#0}::{closure#0}>>, alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>
[        22.732] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/raw.rs:325:13
[        23.018] [event-context-skeleton-ddgo] [err]   61:     0x7f209908d69d - <tokio[a99d4c33085cc326]::runtime::task::raw::RawTask>::poll
[        23.018] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/raw.rs:255:18
[        23.018] [event-context-skeleton-ddgo] [err]   62:     0x7f2099095442 - <tokio[a99d4c33085cc326]::runtime::task::LocalNotified<alloc[6fedee528f97f968]::sync::Arc<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::handle::Handle>>>::run
[        23.018] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/mod.rs:509:13
[        23.018] [event-context-skeleton-ddgo] [err]   63:     0x7f2099002f9f - <tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Context>::run_task::{closure#0}
[        23.018] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/worker.rs:600:18
[        23.019] [event-context-skeleton-ddgo] [err]   64:     0x7f2099091dc1 - tokio[a99d4c33085cc326]::task::coop::with_budget::<core[ecc4e217c0cb0dbe]::result::Result<alloc[6fedee528f97f968]::boxed::Box<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Core>, ()>, <tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Context>::run_task::{closure#0}>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:167:5
[        23.019] [event-context-skeleton-ddgo] [err]   65:     0x7f2099091dc1 - tokio[a99d4c33085cc326]::task::coop::budget::<core[ecc4e217c0cb0dbe]::result::Result<alloc[6fedee528f97f968]::boxed::Box<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Core>, ()>, <tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Context>::run_task::{closure#0}>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:133:5
[        23.019] [event-context-skeleton-ddgo] [err]   66:     0x7f2099091dc1 - <tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Context>::run_task
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/worker.rs:591:9
[        23.019] [event-context-skeleton-ddgo] [err]   67:     0x7f209909027d - <tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Context>::run
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/worker.rs:539:29
[        23.019] [event-context-skeleton-ddgo] [err]   68:     0x7f2098ff98f8 - tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure#0}
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/worker.rs:504:24
[        23.019] [event-context-skeleton-ddgo] [err]   69:     0x7f2098f9a2cb - <tokio[a99d4c33085cc326]::runtime::context::scoped::Scoped<tokio[a99d4c33085cc326]::runtime::scheduler::Context>>::set::<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure#0}, ()>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/scoped.rs:40:9
[        23.019] [event-context-skeleton-ddgo] [err]   70:     0x7f2098ff51c9 - tokio[a99d4c33085cc326]::runtime::context::set_scheduler::<(), tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure#0}>::{closure#0}
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context.rs:176:38
[        23.019] [event-context-skeleton-ddgo] [err]   71:     0x7f2098fa88b1 - <std[76459fe1f20d1bd4]::thread::local::LocalKey<tokio[a99d4c33085cc326]::runtime::context::Context>>::try_with::<tokio[a99d4c33085cc326]::runtime::context::set_scheduler<(), tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure#0}>::{closure#0}, ()>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:513:12
[        23.019] [event-context-skeleton-ddgo] [err]   72:     0x7f2098fa8054 - <std[76459fe1f20d1bd4]::thread::local::LocalKey<tokio[a99d4c33085cc326]::runtime::context::Context>>::with::<tokio[a99d4c33085cc326]::runtime::context::set_scheduler<(), tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure#0}>::{closure#0}, ()>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:477:20
[        23.019] [event-context-skeleton-ddgo] [err]   73:     0x7f2098fda22e - tokio[a99d4c33085cc326]::runtime::context::set_scheduler::<(), tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::run::{closure#0}::{closure#0}>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context.rs:176:17
[        23.019] [event-context-skeleton-ddgo] [err]   74:     0x7f2099006248 - tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::run::{closure#0}
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/worker.rs:499:9
[        23.019] [event-context-skeleton-ddgo] [err]   75:     0x7f2098fe15a3 - tokio[a99d4c33085cc326]::runtime::context::runtime::enter_runtime::<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::run::{closure#0}, ()>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/runtime.rs:65:16
[        23.019] [event-context-skeleton-ddgo] [err]   76:     0x7f20990ace4d - tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::run
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/worker.rs:491:5
[        23.019] [event-context-skeleton-ddgo] [err]   77:     0x7f2098ffbf4b - <tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/worker.rs:457:45
[        23.019] [event-context-skeleton-ddgo] [err]   78:     0x7f20990b69b9 - <tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}> as core[ecc4e217c0cb0dbe]::future::future::Future>::poll
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/blocking/task.rs:42:21
[        23.019] [event-context-skeleton-ddgo] [err]   79:     0x7f2099000b62 - <tokio[a99d4c33085cc326]::runtime::task::core::Core<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>>::poll::{closure#0}
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/core.rs:365:24
[        23.019] [event-context-skeleton-ddgo] [err]   80:     0x7f209906b92f - <tokio[a99d4c33085cc326]::loom::std::unsafe_cell::UnsafeCell<tokio[a99d4c33085cc326]::runtime::task::core::Stage<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>>>>::with_mut::<core[ecc4e217c0cb0dbe]::task::poll::Poll<()>, <tokio[a99d4c33085cc326]::runtime::task::core::Core<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>>::poll::{closure#0}>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/loom/std/unsafe_cell.rs:16:9
[        23.019] [event-context-skeleton-ddgo] [err]   81:     0x7f209906b92f - <tokio[a99d4c33085cc326]::runtime::task::core::Core<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>>::poll
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/core.rs:354:30
[        23.019] [event-context-skeleton-ddgo] [err]   82:     0x7f2098ff6e4c - tokio[a99d4c33085cc326]::runtime::task::harness::poll_future::<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>::{closure#0}
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:535:30
[        23.019] [event-context-skeleton-ddgo] [err]   83:     0x7f20990d8a70 - <core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<tokio[a99d4c33085cc326]::runtime::task::harness::poll_future<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>::{closure#0}> as core[ecc4e217c0cb0dbe]::ops::function::FnOnce<()>>::call_once
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
[        23.019] [event-context-skeleton-ddgo] [err]   84:     0x7f2098fe4877 - std[76459fe1f20d1bd4]::panicking::catch_unwind::do_call::<core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<tokio[a99d4c33085cc326]::runtime::task::harness::poll_future<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>::{closure#0}>, core[ecc4e217c0cb0dbe]::task::poll::Poll<()>>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
[        23.019] [event-context-skeleton-ddgo] [err]   85:     0x7f20990e3f3b - __rust_try
[        23.019] [event-context-skeleton-ddgo] [err]   86:     0x7f2098fbdaaf - std[76459fe1f20d1bd4]::panicking::catch_unwind::<core[ecc4e217c0cb0dbe]::task::poll::Poll<()>, core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<tokio[a99d4c33085cc326]::runtime::task::harness::poll_future<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>::{closure#0}>>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
[        23.019] [event-context-skeleton-ddgo] [err]   87:     0x7f2098fbc13c - std[76459fe1f20d1bd4]::panic::catch_unwind::<core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<tokio[a99d4c33085cc326]::runtime::task::harness::poll_future<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>::{closure#0}>, core[ecc4e217c0cb0dbe]::task::poll::Poll<()>>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
[        23.019] [event-context-skeleton-ddgo] [err]   88:     0x7f2098fdfe4e - tokio[a99d4c33085cc326]::runtime::task::harness::poll_future::<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:523:18
[        23.019] [event-context-skeleton-ddgo] [err]   89:     0x7f20990438d4 - <tokio[a99d4c33085cc326]::runtime::task::harness::Harness<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>>::poll_inner
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:210:27
[        23.019] [event-context-skeleton-ddgo] [err]   90:     0x7f20990440dd - <tokio[a99d4c33085cc326]::runtime::task::harness::Harness<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>>::poll
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:155:20
[        23.019] [event-context-skeleton-ddgo] [err]   91:     0x7f2098fdd9ed - tokio[a99d4c33085cc326]::runtime::task::raw::poll::<tokio[a99d4c33085cc326]::runtime::blocking::task::BlockingTask<<tokio[a99d4c33085cc326]::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/raw.rs:325:13
[        23.019] [event-context-skeleton-ddgo] [err]   92:     0x7f209908d69d - <tokio[a99d4c33085cc326]::runtime::task::raw::RawTask>::poll
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/raw.rs:255:18
[        23.019] [event-context-skeleton-ddgo] [err]   93:     0x7f2099095b66 - <tokio[a99d4c33085cc326]::runtime::task::UnownedTask<tokio[a99d4c33085cc326]::runtime::blocking::schedule::BlockingSchedule>>::run
[        23.019] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/mod.rs:546:13
[        23.019] [event-context-skeleton-ddgo] [err]   94:     0x7f20990473e7 - <tokio[a99d4c33085cc326]::runtime::blocking::pool::Task>::run
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/blocking/pool.rs:161:19
[        23.021] [event-context-skeleton-ddgo] [err]   95:     0x7f2099071b08 - <tokio[a99d4c33085cc326]::runtime::blocking::pool::Inner>::run
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/blocking/pool.rs:516:22
[        23.021] [event-context-skeleton-ddgo] [err]   96:     0x7f2099001ef3 - <tokio[a99d4c33085cc326]::runtime::blocking::pool::Spawner>::spawn_thread::{closure#0}
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/blocking/pool.rs:474:47
[        23.021] [event-context-skeleton-ddgo] [err]   97:     0x7f2098fd3784 - std[76459fe1f20d1bd4]::sys::backtrace::__rust_begin_short_backtrace::<<tokio[a99d4c33085cc326]::runtime::blocking::pool::Spawner>::spawn_thread::{closure#0}, ()>
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:160:18
[        23.021] [event-context-skeleton-ddgo] [err]   98:     0x7f2098ff9249 - std[76459fe1f20d1bd4]::thread::lifecycle::spawn_unchecked::<<tokio[a99d4c33085cc326]::runtime::blocking::pool::Spawner>::spawn_thread::{closure#0}, ()>::{closure#1}::{closure#0}
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/lifecycle.rs:92:13
[        23.021] [event-context-skeleton-ddgo] [err]   99:     0x7f20990d92c9 - <core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<std[76459fe1f20d1bd4]::thread::lifecycle::spawn_unchecked<<tokio[a99d4c33085cc326]::runtime::blocking::pool::Spawner>::spawn_thread::{closure#0}, ()>::{closure#1}::{closure#0}> as core[ecc4e217c0cb0dbe]::ops::function::FnOnce<()>>::call_once
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274:9
[        23.021] [event-context-skeleton-ddgo] [err]  100:     0x7f2098fe55bf - std[76459fe1f20d1bd4]::panicking::catch_unwind::do_call::<core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<std[76459fe1f20d1bd4]::thread::lifecycle::spawn_unchecked<<tokio[a99d4c33085cc326]::runtime::blocking::pool::Spawner>::spawn_thread::{closure#0}, ()>::{closure#1}::{closure#0}>, ()>
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:581:40
[        23.021] [event-context-skeleton-ddgo] [err]  101:     0x7f20990e3f3b - __rust_try
[        23.021] [event-context-skeleton-ddgo] [err]  102:     0x7f2098fbfd0e - std[76459fe1f20d1bd4]::panicking::catch_unwind::<(), core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<std[76459fe1f20d1bd4]::thread::lifecycle::spawn_unchecked<<tokio[a99d4c33085cc326]::runtime::blocking::pool::Spawner>::spawn_thread::{closure#0}, ()>::{closure#1}::{closure#0}>>
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:544:19
[        23.021] [event-context-skeleton-ddgo] [err]  103:     0x7f2098fbc9ed - std[76459fe1f20d1bd4]::panic::catch_unwind::<core[ecc4e217c0cb0dbe]::panic::unwind_safe::AssertUnwindSafe<std[76459fe1f20d1bd4]::thread::lifecycle::spawn_unchecked<<tokio[a99d4c33085cc326]::runtime::blocking::pool::Spawner>::spawn_thread::{closure#0}, ()>::{closure#1}::{closure#0}>, ()>
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359:14
[        23.021] [event-context-skeleton-ddgo] [err]  104:     0x7f2098ff3c8d - std[76459fe1f20d1bd4]::thread::lifecycle::spawn_unchecked::<<tokio[a99d4c33085cc326]::runtime::blocking::pool::Spawner>::spawn_thread::{closure#0}, ()>::{closure#1}
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/lifecycle.rs:90:26
[        23.021] [event-context-skeleton-ddgo] [err]  105:     0x7f209900888f - <std[76459fe1f20d1bd4]::thread::lifecycle::spawn_unchecked<<tokio[a99d4c33085cc326]::runtime::blocking::pool::Spawner>::spawn_thread::{closure#0}, ()>::{closure#1} as core[ecc4e217c0cb0dbe]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
[        23.021] [event-context-skeleton-ddgo] [err]  106:     0x7f2099416609 - <alloc[6fedee528f97f968]::boxed::Box<dyn core[ecc4e217c0cb0dbe]::ops::function::FnOnce<(), Output = ()> + core[ecc4e217c0cb0dbe]::marker::Send> as core[ecc4e217c0cb0dbe]::ops::function::FnOnce<()>>::call_once
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2206:9
[        23.021] [event-context-skeleton-ddgo] [err]  107:     0x7f20993b8a26 - <std[76459fe1f20d1bd4]::sys::thread::unix::Thread>::new::thread_start
[        23.021] [event-context-skeleton-ddgo] [err]                                at /home/bits/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/thread/unix.rs:119:17
[        23.024] [event-context-skeleton-ddgo] [err]  108:     0x7f20e74f0ac3 - <unknown>
[        23.024] [event-context-skeleton-ddgo] [err]  109:     0x7f20e7581a74 - clone
[        23.024] [event-context-skeleton-ddgo] [err]  110:                0x0 - <unknown>
```