### PR TITLE
Add leader_epoch getter on BorrowedMessage and setter on TopicPartitionListElem

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -404,9 +404,10 @@ impl<'a> BorrowedMessage<'a> {
         self.ptr.len
     }
 
-    /// Returns the epoch number of the message -1 if unavailable.
-    pub fn leader_epoch(&self) -> i32 {
-        unsafe { rdsys::rd_kafka_message_leader_epoch(self.ptr.ptr()) }
+    /// Returns the leader epoch of the message, or `None` if unavailable.
+    pub fn leader_epoch(&self) -> Option<i32> {
+        let epoch = unsafe { rdsys::rd_kafka_message_leader_epoch(self.ptr.ptr()) };
+        Some(epoch).filter(|&e| e >= 0)
     }
 
     /// Clones the content of the `BorrowedMessage` and returns an

--- a/src/message.rs
+++ b/src/message.rs
@@ -404,6 +404,11 @@ impl<'a> BorrowedMessage<'a> {
         self.ptr.len
     }
 
+    /// Returns the epoch number of the message -1 if unavailable.
+    pub fn leader_epoch(&self) -> i32 {
+        unsafe { rdsys::rd_kafka_message_leader_epoch(self.ptr.ptr()) }
+    }
+
     /// Clones the content of the `BorrowedMessage` and returns an
     /// [`OwnedMessage`] that can outlive the consumer.
     ///

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,5 +1,6 @@
 //! Store and manipulate Kafka messages.
 
+use crate::topic_partition_list::LEADER_EPOCH_UNAVAILABLE;
 use std::ffi::CStr;
 use std::fmt;
 use std::marker::PhantomData;
@@ -407,7 +408,7 @@ impl<'a> BorrowedMessage<'a> {
     /// Returns the leader epoch of the message, or `None` if unavailable.
     pub fn leader_epoch(&self) -> Option<i32> {
         let epoch = unsafe { rdsys::rd_kafka_message_leader_epoch(self.ptr.ptr()) };
-        Some(epoch).filter(|&e| e >= 0)
+        Some(epoch).filter(|&e| e != LEADER_EPOCH_UNAVAILABLE)
     }
 
     /// Clones the content of the `BorrowedMessage` and returns an

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -159,6 +159,11 @@ impl<'a> TopicPartitionListElem<'a> {
     pub fn leader_epoch(&self) -> i32 {
         unsafe { rdsys::rd_kafka_topic_partition_get_leader_epoch(self.ptr) }
     }
+
+    /// Sets the leader epoch for this entry. Pass -1 if unknown.
+    pub fn set_leader_epoch(&mut self, leader_epoch: i32) {
+        unsafe { rdsys::rd_kafka_topic_partition_set_leader_epoch(self.ptr, leader_epoch) }
+    }
 }
 
 impl<'a> PartialEq for TopicPartitionListElem<'a> {

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -16,6 +16,7 @@ use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::util::{self, KafkaDrop, NativePtr};
 
 const PARTITION_UNASSIGNED: i32 = -1;
+pub(crate) const LEADER_EPOCH_UNAVAILABLE: i32 = -1;
 
 const OFFSET_BEGINNING: i64 = rdsys::RD_KAFKA_OFFSET_BEGINNING as i64;
 const OFFSET_END: i64 = rdsys::RD_KAFKA_OFFSET_END as i64;
@@ -155,9 +156,10 @@ impl<'a> TopicPartitionListElem<'a> {
         self.ptr.metadata_size = metadata.len();
     }
 
-    /// Returns leader epoch associated with the entry.
-    pub fn leader_epoch(&self) -> i32 {
-        unsafe { rdsys::rd_kafka_topic_partition_get_leader_epoch(self.ptr) }
+    /// Returns leader epoch associated with the entry, or `None` if unavailable.
+    pub fn leader_epoch(&self) -> Option<i32> {
+        let epoch = unsafe { rdsys::rd_kafka_topic_partition_get_leader_epoch(self.ptr) };
+        Some(epoch).filter(|&e| e != LEADER_EPOCH_UNAVAILABLE)
     }
 
     /// Sets the leader epoch for this entry. Pass `None` if unknown.
@@ -165,7 +167,7 @@ impl<'a> TopicPartitionListElem<'a> {
         unsafe {
             rdsys::rd_kafka_topic_partition_set_leader_epoch(
                 self.ptr,
-                leader_epoch.unwrap_or(-1),
+                leader_epoch.unwrap_or(LEADER_EPOCH_UNAVAILABLE),
             )
         }
     }

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -160,9 +160,14 @@ impl<'a> TopicPartitionListElem<'a> {
         unsafe { rdsys::rd_kafka_topic_partition_get_leader_epoch(self.ptr) }
     }
 
-    /// Sets the leader epoch for this entry. Pass -1 if unknown.
-    pub fn set_leader_epoch(&mut self, leader_epoch: i32) {
-        unsafe { rdsys::rd_kafka_topic_partition_set_leader_epoch(self.ptr, leader_epoch) }
+    /// Sets the leader epoch for this entry. Pass `None` if unknown.
+    pub fn set_leader_epoch(&mut self, leader_epoch: Option<i32>) {
+        unsafe {
+            rdsys::rd_kafka_topic_partition_set_leader_epoch(
+                self.ptr,
+                leader_epoch.unwrap_or(-1),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Exposes two thin FFI wrappers needed for KIP-320 stale offset detection:

- `BorrowedMessage::leader_epoch()` → `rd_kafka_message_leader_epoch()` (returns -1 if unavailable)
- `TopicPartitionListElem::set_leader_epoch()` → `rd_kafka_topic_partition_set_leader_epoch()` (setter alongside the existing getter)

## Why

This allows for UKCL consumers to thread the leader epoch from a consumed message through to the commit call, so the broker can reject stale offsets carrying wrong leader epoch after unclean leader election, see [1203](https://app.datadoghq.com/cases/SPPF-1203)